### PR TITLE
changed download urls to use https in download.mdx

### DIFF
--- a/docs/desktop/download.mdx
+++ b/docs/desktop/download.mdx
@@ -17,19 +17,19 @@ You can also download the following applications directly by clicking on the cor
 
 # Windows
 
--   [Intel/AMD 64-bit](http://cdn.filen.io/@filen/desktop/release/latest/Filen_win_x64.exe)
--   [ARM 64-bit](http://cdn.filen.io/@filen/desktop/release/latest/Filen_win_x64.exe)
+-   [Intel/AMD 64-bit](https://cdn.filen.io/@filen/desktop/release/latest/Filen_win_x64.exe)
+-   [ARM 64-bit](https://cdn.filen.io/@filen/desktop/release/latest/Filen_win_x64.exe)
 
 # macOS
 
--   [Intel/AMD 64-bit](http://cdn.filen.io/@filen/desktop/release/latest/Filen_mac_x64.dmg)
--   [Apple Silicon - M Chipset](http://cdn.filen.io/@filen/desktop/release/latest/Filen_mac_arm64.dmg)
+-   [Intel/AMD 64-bit](https://cdn.filen.io/@filen/desktop/release/latest/Filen_mac_x64.dmg)
+-   [Apple Silicon - M Chipset](https://cdn.filen.io/@filen/desktop/release/latest/Filen_mac_arm64.dmg)
 
 # Linux
 
--   [Intel/AMD 64-bit .deb](http://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_amd64.deb)
--   [Intel/AMD 64-bit .rpm](http://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_x86_64.rpm)
--   [Intel/AMD 64-bit .AppImage](http://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_x86_64.AppImage)
--   [ARM 64-bit .deb](http://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_arm64.deb)
--   [ARM 64-bit .rpm](http://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_aarch64.rpm)
--   [ARM 64-bit .AppImage](http://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_arm64.AppImage)
+-   [Intel/AMD 64-bit .deb](https://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_amd64.deb)
+-   [Intel/AMD 64-bit .rpm](https://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_x86_64.rpm)
+-   [Intel/AMD 64-bit .AppImage](https://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_x86_64.AppImage)
+-   [ARM 64-bit .deb](https://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_arm64.deb)
+-   [ARM 64-bit .rpm](https://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_aarch64.rpm)
+-   [ARM 64-bit .AppImage](https://cdn.filen.io/@filen/desktop/release/latest/Filen_linux_arm64.AppImage)


### PR DESCRIPTION
This PR changes the cdn links in the downloads webpage _(docs/desktop/download.mdx)_ to use `https` (previously `http`) to fix bug causing the link to fail (no download occurs) in Chromium.

This was motivated because I like the premise and dev-support of Filen, and believe there are many potential customers where this may be a point of friction. I was able to download the file with the http link via `wget`, but I'm assuming that's not intended to be required. 